### PR TITLE
Remove exercise redundancy

### DIFF
--- a/src/ExerciseList.hs
+++ b/src/ExerciseList.hs
@@ -2,24 +2,20 @@ module ExerciseList where
 
 import qualified Data.Map as M
 
-exerciseMap :: M.Map String ExerciseInfo
-exerciseMap = M.fromList
-  [ ("Types1", ExerciseInfo "Types1" "types" "Types1.hs" False "myFirstVariable is a number. What numeric type can you fill in?")
-  , ("Types2", ExerciseInfo "Types2" "types" "Types2.hs" False "What are the component types of aTuple? Are the values in aList really 'Int'?")
-  , ("Recursion1", ExerciseInfo "Recursion1" "recursion" "Recursion1.hs" True "Start with a base pattern of [], and then define how you would incorporate the first element in the list with the recursive result.")
-  ]
-
 data ExerciseInfo = ExerciseInfo
   { exerciseName :: String
   , exerciseDirectory :: String
-  , exerciseModuleFile :: String
   , exerciseIsRunnable :: Bool
   , exerciseHint :: String
   } deriving (Show, Eq)
 
-exerciseList :: [ExerciseInfo]
-exerciseList =
-  [ ExerciseInfo "Types1" "types" "Types1.hs" False "myFirstVariable is a number. What numeric type can you fill in?"
-  , ExerciseInfo "Types2" "types" "Types2.hs" False "What are the component types of aTuple? Are the values in aList really 'Int'?"
-  , ExerciseInfo "Recursion1" "recursion" "Recursion1.hs" True "Start with a base pattern of [], and then define how you would incorporate the first element in the list with the recursive result."
+allExercises :: [ExerciseInfo]
+allExercises =
+  [ ExerciseInfo "Types1" "types" False "myFirstVariable is a number. What numeric type can you fill in?"
+  , ExerciseInfo "Types2" "types" False "What are the component types of aTuple? Are the values in aList really 'Int'?"
+  , ExerciseInfo "Recursion1" "recursion" True "Start with a base pattern of [], and then define how you would incorporate the first element in the list with the recursive result."
   ]
+
+allExercisesMap :: M.Map String ExerciseInfo
+allExercisesMap = M.fromList
+  [(exerciseName ex, ex) | ex <- allExercises]

--- a/src/RunExercises.hs
+++ b/src/RunExercises.hs
@@ -6,10 +6,10 @@ import           System.Directory
 import           System.Process
 
 import           Config
-import           ExerciseList (exerciseMap)
+import           ExerciseList (allExercisesMap)
 import           Utils
 
 runExercise :: ProgramConfig -> String -> IO ()
-runExercise config exerciseName = case M.lookup exerciseName exerciseMap of
+runExercise config exerciseName = case M.lookup exerciseName allExercisesMap of
   Nothing -> progPutStrLn config $ "Could not find exercise: " ++ exerciseName ++ "!"
   Just exInfo -> compileExercise_ config exInfo

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -21,12 +21,16 @@ isHaskellFile = isSuffixOf ".hs"
 haskellModuleName :: FilePath -> FilePath
 haskellModuleName fp = dropEnd 3 (basename fp)
 
+haskellFileName :: FilePath -> FilePath
+haskellFileName exName = exName ++ ".hs"
+
 data RunResult =
   CompileError | TestFailed | RunSuccess
   deriving (Show, Eq)
 
 compileExercise :: ProgramConfig -> ExerciseInfo -> IO RunResult
-compileExercise config (ExerciseInfo _ exDirectory exFilename exIsRunnable _) = do
+compileExercise config (ExerciseInfo exerciseName exDirectory exIsRunnable _) = do
+  let exFilename = haskellFileName exerciseName
   let root = projectRoot config
   let fullSourcePath = root `pathJoin` exercisesExt config `pathJoin` exDirectory `pathJoin` exFilename
   let genDirPath = root `pathJoin` "/generated_files/" `pathJoin` exDirectory
@@ -89,4 +93,4 @@ fileContainsNotDone fullFp = do
     isDoneLine l = (upper . (filter (not . isSpace)) $ l) == "--IAMNOTDONE"
 
 fullExerciseFp :: FilePath -> FilePath -> ExerciseInfo -> FilePath
-fullExerciseFp projectRoot exercisesExt (ExerciseInfo _ exDir exFile _ _) = projectRoot `pathJoin` exercisesExt `pathJoin` exDir `pathJoin` exFile
+fullExerciseFp projectRoot exercisesExt (ExerciseInfo exName exDir _ _) = projectRoot `pathJoin` exercisesExt `pathJoin` exDir `pathJoin` haskellFileName exName

--- a/src/Watcher.hs
+++ b/src/Watcher.hs
@@ -13,11 +13,11 @@ import ExerciseList
 import Utils
 
 watchExercises :: ProgramConfig -> IO ()
-watchExercises config = runExerciseWatch config exerciseList
+watchExercises config = runExerciseWatch config allExercises
 
 shouldCheckFile :: ExerciseInfo -> Event -> Bool
-shouldCheckFile (ExerciseInfo _ _ exFile _ _) (Added fp _ _) = basename fp == exFile
-shouldCheckFile (ExerciseInfo _ _ exFile _ _) (Modified fp _ _) = basename fp == exFile
+shouldCheckFile (ExerciseInfo exName _ _ _) (Added fp _ _) = basename fp == haskellFileName exName
+shouldCheckFile (ExerciseInfo exName _ _ _) (Modified fp _ _) = basename fp == haskellFileName exName
 shouldCheckFile _ _ = False
 
 -- This event should be a modification of one of our exercise files

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -71,7 +71,7 @@ compileTests1 paths = before (compileBeforeHook paths exInfo "types1_bad.output"
       exit `shouldBe` CompileError
       isFailureOutput output
   where
-    exInfo = ExerciseInfo "Types1Bad" "types" "Types1Bad.hs" False ""
+    exInfo = ExerciseInfo "Types1Bad" "types" False ""
 
 compileTests2 :: (FilePath, FilePath) -> Spec
 compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output") $
@@ -80,7 +80,7 @@ compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output
       exit `shouldBe` RunSuccess
       isSuccessOutput output
   where
-    exInfo = ExerciseInfo "Types1Good" "types" "Types1Good.hs" False ""
+    exInfo = ExerciseInfo "Types1Good" "types" False ""
 
 compileAndRunTestFail1 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion1_bad1.output") $
@@ -89,7 +89,7 @@ compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion
       exit `shouldBe` CompileError
       isFailureOutput output
   where
-    exInfo = ExerciseInfo "Recursion1Bad1" "recursion" "Recursion1Bad1.hs" True ""
+    exInfo = ExerciseInfo "Recursion1Bad1" "recursion" True ""
 
 compileAndRunTestFail2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion1_bad2.output") $
@@ -98,7 +98,7 @@ compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion
       isRunFailureOutput output
       exit `shouldBe` TestFailed
   where
-    exInfo = ExerciseInfo "Recursion1Bad2" "recursion" "Recursion1Bad2.hs" True ""
+    exInfo = ExerciseInfo "Recursion1Bad2" "recursion" True ""
 
 compileAndRunTestPass :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1_good.output") $
@@ -107,7 +107,7 @@ compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
   where
-    exInfo = ExerciseInfo "Recursion1Good" "recursion" "Recursion1Good.hs" True ""
+    exInfo = ExerciseInfo "Recursion1Good" "recursion" True ""
 
 compileAndRunTestPass2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion2.output") $
@@ -116,7 +116,7 @@ compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
   where
-    exInfo = ExerciseInfo "Recursion" "recursion" "Recursion2.hs" True ""
+    exInfo = ExerciseInfo "Recursion2" "recursion" True ""
 
 
 
@@ -125,8 +125,8 @@ compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion
 
 watchTestExercises :: [ExerciseInfo]
 watchTestExercises =
-  [ ExerciseInfo "Types1" "watcher_types" "Types1.hs" False "What type should you fill in for the variable?"
-  , ExerciseInfo "Types2" "watcher_types" "Types2.hs" False "What type can you fill in for the tuple?"
+  [ ExerciseInfo "Types1" "watcher_types" False "What type should you fill in for the variable?"
+  , ExerciseInfo "Types2" "watcher_types" False "What type can you fill in for the tuple?"
   ]
 
 watchTests :: (FilePath, FilePath) -> Spec


### PR DESCRIPTION
1. Remove exercise filename from list of fields for exercise info. We can always derive this from the exercise name.
2. Remove the duplication of exercise definitions by deriving `exerciseMap` from `exerciseList`.