### PR TITLE
Executable exercises

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -22,10 +22,12 @@ main = do
         then progPutStrLn config "Haskellings requires a sub-command!"
         else do
           let command = head args
-          if command == "run"
-            then if length args < 2
+          case command of
+            "run" -> if length args < 2
               then progPutStrLn config "Run command requires an exercise name!"
               else runExercise config (args !! 1)
-          else if command == "watch"
-            then watchExercises config
-            else progPutStrLn config $ command ++ " is not implemented yet!"
+            "watch" -> watchExercises config
+            "exec" -> if length args < 2
+              then progPutStrLn config "Exec command requires an exercise name!"
+              else execExercise config (args !! 1)
+            _ -> progPutStrLn config $ command ++ " is not implemented yet!"

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,5 +1,6 @@
 module Config where
 
+
 import           Control.Concurrent  (MVar, putMVar, takeMVar)
 import           Control.Monad       (forM)
 import           Data.List           (find, isSuffixOf)
@@ -67,14 +68,14 @@ progReadLine pc = hGetLine (inHandle pc)
 
 -- Perform an action with 'Green' Terminal Text
 withTerminalSuccess :: IO a -> IO a
-withTerminalSuccess action = withTerminalColor Green
+withTerminalSuccess = withTerminalColor Green
 
 -- Perform an action with 'Red' Terminal Text
 withTerminalFailure :: IO a -> IO a
 withTerminalFailure = withTerminalColor Red
 
 -- Perform an action with printed output given a color.
-withTerminalColor :: SGR -> IO a -> IO a
+withTerminalColor :: Color -> IO a -> IO a
 withTerminalColor color action = do
   setSGR [SetColor Foreground Vivid color]
   res <- action

--- a/src/Config.hs
+++ b/src/Config.hs
@@ -1,13 +1,14 @@
 module Config where
 
-import           Control.Concurrent (MVar, putMVar, takeMVar)
-import           Control.Monad      (forM)
-import           Data.List          (find, isSuffixOf)
-import qualified Data.Map           as M
-import           Data.Maybe         (catMaybes)
-import qualified Data.Sequence      as S
+import           Control.Concurrent  (MVar, putMVar, takeMVar)
+import           Control.Monad       (forM)
+import           Data.List           (find, isSuffixOf)
+import qualified Data.Map            as M
+import           Data.Maybe          (catMaybes)
+import qualified Data.Sequence       as S
+import           System.Console.ANSI
 import           System.Directory
-import           System.Environment (lookupEnv)
+import           System.Environment  (lookupEnv)
 import           System.IO
 
 import           DirectoryUtils
@@ -63,6 +64,39 @@ progPrintErr pc = hPrint (errHandle pc)
 
 progReadLine :: ProgramConfig -> IO String
 progReadLine pc = hGetLine (inHandle pc)
+
+-- Perform an action with 'Green' Terminal Text
+withTerminalSuccess :: IO a -> IO a
+withTerminalSuccess action = withTerminalColor Green
+
+-- Perform an action with 'Red' Terminal Text
+withTerminalFailure :: IO a -> IO a
+withTerminalFailure = withTerminalColor Red
+
+-- Perform an action with printed output given a color.
+withTerminalColor :: SGR -> IO a -> IO a
+withTerminalColor color action = do
+  setSGR [SetColor Foreground Vivid color]
+  res <- action
+  setSGR [Reset]
+  return res
+
+-- Print a line, but in Green
+progPutStrLnSuccess :: ProgramConfig -> String -> IO ()
+progPutStrLnSuccess pc output = withTerminalSuccess (progPutStrLn pc output)
+
+-- Print a line, but in Red
+progPutStrLnFailure :: ProgramConfig -> String -> IO ()
+progPutStrLnFailure pc output = withTerminalFailure (progPutStrLn pc output)
+
+-- Create a directory. Run the action depending on that directory,
+-- and then clean the directory up.
+withDirectory :: FilePath -> IO a -> IO a
+withDirectory dirPath action = do
+  createDirectoryIfMissing True dirPath
+  res <- action
+  removeDirectoryRecursive dirPath
+  return res
 
 loadProjectRootAndGhc :: IO (Either ConfigError (FilePath, FilePath))
 loadProjectRootAndGhc = do

--- a/src/ExerciseList.hs
+++ b/src/ExerciseList.hs
@@ -2,60 +2,84 @@ module ExerciseList where
 
 import qualified Data.Map as M
 
+-- There are three types of exercises.
+-- 1. Some succeed once they have compiled (CompileOnly).
+-- 2. Some require that unit tests pass on the exercise functions (UnitTests)
+-- 3. Others involve some degree of IO. The User can use 'haskellings exec' on
+--    these. There is one set of inputs and expected outputs as a quick test,
+--    when the exercise is run via 'haskellings run' or the Watcher.
+data ExerciseType =
+  CompileOnly |
+  UnitTests |
+  -- One set of expected input lines and predicate for output lines.
+  Executable [String] ([String] -> Bool)
+
+-- Manual instances needed because 'Executable' contains a function.
+instance Eq ExerciseType where
+  CompileOnly == CompileOnly = True
+  UnitTests == UnitTests = True
+  (Executable _ _) == (Executable _ _) = True
+  _ == _ = False
+
+instance Show ExerciseType where
+  show CompileOnly      = "CompileOnly"
+  show UnitTests        = "UnitTests"
+  show (Executable _ _) = "Executable"
+
 data ExerciseInfo = ExerciseInfo
-  { exerciseName       :: String
-  , exerciseDirectory  :: String
-  , exerciseIsRunnable :: Bool
-  , exerciseHint       :: String
+  { exerciseName      :: String
+  , exerciseDirectory :: String
+  , exerciseType      :: ExerciseType
+  , exerciseHint      :: String
   } deriving (Show, Eq)
 
 allExercises :: [ExerciseInfo]
 allExercises =
-  [ ExerciseInfo "Expressions" "basics" False "Fill in numeric values in place of '???' for expression3 and expression4."
-  , ExerciseInfo "Types1" "basics" False "Fill in appropriate type signatures for the expressions at the bottom."
-  , ExerciseInfo "Types2" "basics" False "Fill in the missing appropriate type signatures and values at the bottom."
-  , ExerciseInfo "Types3" "basics" False "Fill in the missing appropriate type signatures and values at the bottom."
-  , ExerciseInfo "Types4" "basics" False "Which element of mixedList doesn't belong? How can you fix it?"
-  , ExerciseInfo "Types5" "basics" False "What happens when you change 'String' to '[Char]' and vice-versa?"
-  , ExerciseInfo "Functions1" "functions" True "Fill in the missing appropriate type signatures and values at the bottom, following the earlier examples in the module."
-  , ExerciseInfo "Functions2" "functions" True "When taking a tuple as an input, you can assign a name to each element of the tuple: capitalize (c1, c2, c3) = ..."
-  , ExerciseInfo "Functions3" "functions" True "Define the second function by a partial application of the first."
-  , ExerciseInfo "Functions4" "functions" True "Remember to keep parentheses around the operator when defining it!"
-  , ExerciseInfo "Functions5" "functions" True "For the 'sink' functions, think about partial operator application!"
-  , ExerciseInfo "Functions6" "functions" True "Remember that a String is just a list of characters: [Char]."
-  , ExerciseInfo "Syntax1" "syntax" True "There is no 'elif' like in Python. Use 'else' and then another full 'if' statement."
-  , ExerciseInfo "Syntax2" "syntax" True "You don't need a guard branch for every possible case in countTrue!"
-  , ExerciseInfo "Syntax3" "syntax" True "For your catch-all case, either use an expression name like normal for the input, or use an underscore '_' if you don't need the input."
-  , ExerciseInfo "Syntax4" "syntax" True "Split the function up with the boolean and then use a 'case' statement!"
-  , ExerciseInfo "Syntax5" "syntax" True "Split the problem into small chunks, and make an expression for each chunk in the 'where' clause!"
-  , ExerciseInfo "Syntax6" "syntax" True "Keeping the start of your definitions aligned helps make 'let' clauses much more readable!"
-  , ExerciseInfo "Data1" "data" False "Once you know the types you need, it's simple to add them to a constructor!"
-  , ExerciseInfo "Data2" "data" True "On 'giveFullName', remember to use pattern matching, and that '++' can append strings together!"
-  , ExerciseInfo "Data3" "data" False "You can follow your own conventions with spacing and new lines when defining the record names."
-  , ExerciseInfo "Data4" "data" True "Use pattern matching to deal with different sizes of lists."
-  , ExerciseInfo "Data5" "data" False "What should the underlying types be for each name given in the type signatures?"
-  , ExerciseInfo "Data6" "data" True "How can you quickly change the type synonyms to newtypes? What errors are revealed?"
-  , ExerciseInfo "Typeclasses1" "typeclasses" True "Use a comma separated list within parens to constrain on multiple classes."
-  , ExerciseInfo "Typeclasses2" "typeclasses" True "Remember the class name, type name, and keyword 'where' in instance definitions!"
-  , ExerciseInfo "Typeclasses3" "typeclasses" True "The last function should be polymorphic in both inputs, with different constraints on each!"
-  , ExerciseInfo "Typeclasses4" "typeclasses" True "You can use one typeclass function to help with another! Just don't create a dependency loop between them!"
-  , ExerciseInfo "Typeclasses5" "typeclasses" True "Make use of the existing 'Show' and 'Read' instances of the types."
-  , ExerciseInfo "Recursion1" "recursion" True "Remember the base case! Also remember that 'mod' can help you determine if a number is even."
-  , ExerciseInfo "Recursion2" "recursion" True "1. Sometimes there is no work and only a recursive call! 2. Pattern matches can reveal more than just the head of a list!"
-  , ExerciseInfo "Recursion3" "recursion" True "You can use multiple accumulator arguments if you want!"
-  , ExerciseInfo "Recursion4" "recursion" True "You can't technically use 'tail recursion' but you'll still want a helper function, at least on the second function!"
-  , ExerciseInfo "Lists1" "lists" True "Tail recursion should provide you with some inspiration for your folding functions!"
-  , ExerciseInfo "Lists2" "lists" True "Your countdown doesn't need to end exactly with 0."
-  , ExerciseInfo "Lists3" "lists" True "Remember 3 steps for a comprehension: 1. source 2. filter 3. result."
-  , ExerciseInfo "Lists4" "lists" True "Remember 'show' and string appending!"
-  , ExerciseInfo "Functors" "monads" True "You can use the underlying functor instances when creating your functor!"
-  , ExerciseInfo "Applicatives" "monads" True "You can use 'fmap' (<$>) to wrap a function in the Applicative before applying <*>!"
-  , ExerciseInfo "Monoids" "monads" True "Think about what you would use as the identity element for each item!"
-  , ExerciseInfo "Monads1" "monads" True "The bind operator (>>=) allows us to pass values from one monadic function to another without needing to unwrap in between!"
-  , ExerciseInfo "Monads2" "monads" True "The key is understanding what goes on each side of '<-' operator. The wrapped computation goes on the right, the unwrapped result goes on the left."
-  , ExerciseInfo "Monads3" "monads" True "You can still use an 'if' inside do-syntax! Just make sure that both branches are monadic actions!"
-  , ExerciseInfo "Monads4" "monads" True "You'll have to wrap the string values in their own lists to use the monoid instance!"
-  , ExerciseInfo "Monads5" "monads" True "Remember that 'execState' will discard the computation result!"
+  [ ExerciseInfo "Expressions" "basics" CompileOnly "Fill in numeric values in place of '???' for expression3 and expression4."
+  , ExerciseInfo "Types1" "basics" CompileOnly "Fill in appropriate type signatures for the expressions at the bottom."
+  , ExerciseInfo "Types2" "basics" CompileOnly "Fill in the missing appropriate type signatures and values at the bottom."
+  , ExerciseInfo "Types3" "basics" CompileOnly "Fill in the missing appropriate type signatures and values at the bottom."
+  , ExerciseInfo "Types4" "basics" CompileOnly "Which element of mixedList doesn't belong? How can you fix it?"
+  , ExerciseInfo "Types5" "basics" CompileOnly "What happens when you change 'String' to '[Char]' and vice-versa?"
+  , ExerciseInfo "Functions1" "functions" UnitTests "Fill in the missing appropriate type signatures and values at the bottom, following the earlier examples in the module."
+  , ExerciseInfo "Functions2" "functions" UnitTests "When taking a tuple as an input, you can assign a name to each element of the tuple: capitalize (c1, c2, c3) = ..."
+  , ExerciseInfo "Functions3" "functions" UnitTests "Define the second function by a partial application of the first."
+  , ExerciseInfo "Functions4" "functions" UnitTests "Remember to keep parentheses around the operator when defining it!"
+  , ExerciseInfo "Functions5" "functions" UnitTests "For the 'sink' functions, think about partial operator application!"
+  , ExerciseInfo "Functions6" "functions" UnitTests "Remember that a String is just a list of characters: [Char]."
+  , ExerciseInfo "Syntax1" "syntax" UnitTests "There is no 'elif' like in Python. Use 'else' and then another full 'if' statement."
+  , ExerciseInfo "Syntax2" "syntax" UnitTests "You don't need a guard branch for every possible case in countUnitTests!"
+  , ExerciseInfo "Syntax3" "syntax" UnitTests "For your catch-all case, either use an expression name like normal for the input, or use an underscore '_' if you don't need the input."
+  , ExerciseInfo "Syntax4" "syntax" UnitTests "Split the function up with the boolean and then use a 'case' statement!"
+  , ExerciseInfo "Syntax5" "syntax" UnitTests "Split the problem into small chunks, and make an expression for each chunk in the 'where' clause!"
+  , ExerciseInfo "Syntax6" "syntax" UnitTests "Keeping the start of your definitions aligned helps make 'let' clauses much more readable!"
+  , ExerciseInfo "Data1" "data" CompileOnly "Once you know the types you need, it's simple to add them to a constructor!"
+  , ExerciseInfo "Data2" "data" UnitTests "On 'giveFullName', remember to use pattern matching, and that '++' can append strings together!"
+  , ExerciseInfo "Data3" "data" CompileOnly "You can follow your own conventions with spacing and new lines when defining the record names."
+  , ExerciseInfo "Data4" "data" UnitTests "Use pattern matching to deal with different sizes of lists."
+  , ExerciseInfo "Data5" "data" CompileOnly "What should the underlying types be for each name given in the type signatures?"
+  , ExerciseInfo "Data6" "data" UnitTests "How can you quickly change the type synonyms to newtypes? What errors are revealed?"
+  , ExerciseInfo "Typeclasses1" "typeclasses" UnitTests "Use a comma separated list within parens to constrain on multiple classes."
+  , ExerciseInfo "Typeclasses2" "typeclasses" UnitTests "Remember the class name, type name, and keyword 'where' in instance definitions!"
+  , ExerciseInfo "Typeclasses3" "typeclasses" UnitTests "The last function should be polymorphic in both inputs, with different constraints on each!"
+  , ExerciseInfo "Typeclasses4" "typeclasses" UnitTests "You can use one typeclass function to help with another! Just don't create a dependency loop between them!"
+  , ExerciseInfo "Typeclasses5" "typeclasses" UnitTests "Make use of the existing 'Show' and 'Read' instances of the types."
+  , ExerciseInfo "Recursion1" "recursion" UnitTests "Remember the base case! Also remember that 'mod' can help you determine if a number is even."
+  , ExerciseInfo "Recursion2" "recursion" UnitTests "1. Sometimes there is no work and only a recursive call! 2. Pattern matches can reveal more than just the head of a list!"
+  , ExerciseInfo "Recursion3" "recursion" UnitTests "You can use multiple accumulator arguments if you want!"
+  , ExerciseInfo "Recursion4" "recursion" UnitTests "You can't technically use 'tail recursion' but you'll still want a helper function, at least on the second function!"
+  , ExerciseInfo "Lists1" "lists" UnitTests "Tail recursion should provide you with some inspiration for your folding functions!"
+  , ExerciseInfo "Lists2" "lists" UnitTests "Your countdown doesn't need to end exactly with 0."
+  , ExerciseInfo "Lists3" "lists" UnitTests "Remember 3 steps for a comprehension: 1. source 2. filter 3. result."
+  , ExerciseInfo "Lists4" "lists" UnitTests "Remember 'show' and string appending!"
+  , ExerciseInfo "Functors" "monads" UnitTests "You can use the underlying functor instances when creating your functor!"
+  , ExerciseInfo "Applicatives" "monads" UnitTests "You can use 'fmap' (<$>) to wrap a function in the Applicative before applying <*>!"
+  , ExerciseInfo "Monoids" "monads" UnitTests "Think about what you would use as the identity element for each item!"
+  , ExerciseInfo "Monads1" "monads" UnitTests "The bind operator (>>=) allows us to pass values from one monadic function to another without needing to unwrap in between!"
+  , ExerciseInfo "Monads2" "monads" UnitTests "The key is understanding what goes on each side of '<-' operator. The wrapped computation goes on the right, the unwrapped result goes on the left."
+  , ExerciseInfo "Monads3" "monads" UnitTests "You can still use an 'if' inside do-syntax! Just make sure that both branches are monadic actions!"
+  , ExerciseInfo "Monads4" "monads" UnitTests "You'll have to wrap the string values in their own lists to use the monoid instance!"
+  , ExerciseInfo "Monads5" "monads" UnitTests "Remember that 'execState' will discard the computation result!"
   ]
 
 allExercisesMap :: M.Map String ExerciseInfo

--- a/src/RunExercises.hs
+++ b/src/RunExercises.hs
@@ -6,10 +6,16 @@ import           System.Directory
 import           System.Process
 
 import           Config
-import           ExerciseList     (allExercisesMap)
+import           ExerciseList
 import           Utils
 
 runExercise :: ProgramConfig -> String -> IO ()
 runExercise config exerciseName = case M.lookup exerciseName allExercisesMap of
   Nothing -> progPutStrLn config $ "Could not find exercise: " ++ exerciseName ++ "!"
-  Just exInfo -> compileExercise_ config exInfo
+  Just exInfo -> compileAndRunExercise_ config exInfo
+
+execExercise :: ProgramConfig -> String -> IO ()
+execExercise config exerciseName = case M.lookup exerciseName allExercisesMap of
+  Nothing -> progPutStrLn config $ "Could not find exercise: " ++ exerciseName ++ "!"
+  Just exInfo@(ExerciseInfo _ _ (Executable _ _) _) -> executeExercise config exInfo
+  _ -> progPutStrLn config $ "Exercise " ++ exerciseName ++ " is not executable!"

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -44,10 +44,6 @@ executeExercise config exInfo@(ExerciseInfo exerciseName _ _ _) = do
         (_, _, _, execProcHandle) <- createProcess execSpec
         void $ waitForProcess execProcHandle
 
--- processSpec
--- genExecutablePath
--- exFilename (or just pass exerciseInfo?)
-
 -- Produces 3 Elements for running our exercise:
 -- 1. The 'CreateProcess' that we can run for the compilation.
 -- 2. The directory path for the generated files

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -95,7 +95,13 @@ compileExercise config (ExerciseInfo exerciseName exDirectory exType _) = do
           case execExit of
             ExitFailure code -> do
               setSGR [SetColor Foreground Vivid Red]
-              progPutStrLn config "Unexpected output for exercise: " ++ exFilename
+              progPutStrLn config $ "Encountered error running exercise: " ++ exFilename
+              case execStdOut of
+                Nothing -> return ()
+                Just h  -> hGetContents h >>= progPutStrLn config
+              case execStdErr of
+                Nothing -> return ()
+                Just h  -> hGetContents h >>= progPutStrLn config
               progPutStrLn config "Check the Sample Input and Sample Output in the file."
               progPutStrLn config $ "Then try running it for yourself with 'haskellings exec" ++ haskellModuleName exFilename ++ "'."
               setSGR [Reset]
@@ -115,7 +121,7 @@ compileExercise config (ExerciseInfo exerciseName exDirectory exType _) = do
                   return RunSuccess
                 else do
                   setSGR [SetColor Foreground Vivid Red]
-                  progPutStrLn config "Unexpected output for exercise: " ++ exFilename
+                  progPutStrLn config $ "Unexpected output for exercise: " ++ exFilename
                   progPutStrLn config "Check the Sample Input and Sample Output in the file."
                   progPutStrLn config $ "Then try running it for yourself with 'haskellings exec " ++ haskellModuleName exFilename ++ "'."
                   setSGR [Reset]

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -29,7 +29,8 @@ data RunResult =
   deriving (Show, Eq)
 
 compileExercise :: ProgramConfig -> ExerciseInfo -> IO RunResult
-compileExercise config (ExerciseInfo exerciseName exDirectory exIsRunnable _) = do
+compileExercise config (ExerciseInfo exerciseName exDirectory exType _) = do
+  let exIsRunnable = exType /= CompileOnly
   let exFilename = haskellFileName exerciseName
   let root = projectRoot config
   let fullSourcePath = root `pathJoin` exercisesExt config `pathJoin` exDirectory `pathJoin` exFilename

--- a/src/Utils.hs
+++ b/src/Utils.hs
@@ -1,11 +1,10 @@
 module Utils where
 
-import           Control.Monad       (forM_, void, when)
+import           Control.Monad    (forM_, void, when)
 import           Data.Char
 import           Data.List
 import           Data.List.Extra
-import           Data.Maybe          (fromJust, isJust)
-import           System.Console.ANSI
+import           Data.Maybe       (fromJust, isJust)
 import           System.Directory
 import           System.Exit
 import           System.IO
@@ -29,107 +28,120 @@ data RunResult =
   CompileError | TestFailed | RunSuccess
   deriving (Show, Eq)
 
--- TODO: This function is officially monstrous and needs to be refactored.
-compileExercise :: ProgramConfig -> ExerciseInfo -> IO RunResult
-compileExercise config (ExerciseInfo exerciseName exDirectory exType _) = do
-  let exIsRunnable = exType /= CompileOnly
-  let exFilename = haskellFileName exerciseName
-  let root = projectRoot config
-  let fullSourcePath = root `pathJoin` exercisesExt config `pathJoin` exDirectory `pathJoin` exFilename
-  let genDirPath = root `pathJoin` "/generated_files/" `pathJoin` exDirectory
-  let genExecutablePath = genDirPath `pathJoin` haskellModuleName exFilename
-  createDirectoryIfMissing True genDirPath
-  let baseArgs = [fullSourcePath, "-odir", genDirPath, "-hidir", genDirPath]
-  let execArgs = if exIsRunnable then baseArgs ++ ["-o", genExecutablePath] else baseArgs
-  let finalArgs = case packageDb config of
+executeExercise :: ProgramConfig -> ExerciseInfo -> IO ()
+executeExercise config (ExerciseInfo exerciseName exDirectory exType _) = undefined
+
+-- processSpec
+-- genExecutablePath
+-- exFilename (or just pass exerciseInfo?)
+
+-- Produces 3 Elements for running our exercise:
+-- 1. The 'CreateProcess' that we can run for the compilation.
+-- 2. The directory path for the generated files
+-- 3. The path of the executable we would run (assuming the exercise is executable).
+createExerciseProcess :: ProgramConfig -> ExerciseInfo -> (CreateProcess, FilePath, FilePath)
+createExerciseProcess config (ExerciseInfo exerciseName exDirectory exType _) =
+  (processSpec, genDirPath, genExecutablePath)
+  where
+    exIsRunnable = exType /= CompileOnly
+    exFilename = haskellFileName exerciseName
+    root = projectRoot config
+    fullSourcePath = root `pathJoin` exercisesExt config `pathJoin` exDirectory `pathJoin` exFilename
+    genDirPath = root `pathJoin` "/generated_files/" `pathJoin` exDirectory
+    genExecutablePath = genDirPath `pathJoin` haskellModuleName exFilename
+    baseArgs = [fullSourcePath, "-odir", genDirPath, "-hidir", genDirPath]
+    execArgs = if exIsRunnable then baseArgs ++ ["-o", genExecutablePath] else baseArgs
+    finalArgs = case packageDb config of
         Nothing      -> execArgs
         Just pkgPath -> execArgs ++ ["-package-db", pkgPath]
-  let processSpec = proc (ghcPath config) finalArgs
-  (_, _, procStdErr, procHandle) <- createProcess (processSpec { std_out = CreatePipe, std_err = CreatePipe })
-  exitCode <- waitForProcess procHandle
-  case exitCode of
-    ExitFailure code -> do
-      setSGR [SetColor Foreground Vivid Red]
-      progPutStrLn config $ "Couldn't compile : " ++ exFilename
-      case procStdErr of
+    processSpec = proc (ghcPath config) finalArgs
+
+onCompileFailure :: ProgramConfig -> String -> Maybe Handle -> IO RunResult
+onCompileFailure config exFilename errHandle = withTerminalFailure $ do
+  progPutStrLn config $ "Couldn't compile : " ++ exFilename
+  case errHandle of
+    Nothing -> return ()
+    Just h  -> hGetContents h >>= progPutStrLn config
+  return CompileError
+
+runUnitTestExercise :: ProgramConfig -> FilePath -> String -> IO RunResult
+runUnitTestExercise config genExecutablePath exFilename = do
+  let execSpec = shell genExecutablePath
+  (_, execStdOut, execStdErr, execProcHandle) <- createProcess (execSpec { std_out = CreatePipe, std_err = CreatePipe })
+  execExit <- waitForProcess execProcHandle
+  case execExit of
+    ExitFailure code -> withTerminalFailure $ do
+      progPutStrLn config $ "Tests failed on exercise : " ++ exFilename
+      case execStdErr of
         Nothing -> return ()
         Just h  -> hGetContents h >>= progPutStrLn config
-      setSGR [Reset]
-      removeDirectoryRecursive genDirPath
-      return CompileError
+      case execStdOut of
+        Nothing -> return ()
+        Just h  -> hGetContents h >>= progPutStrLn config
+      return TestFailed
     ExitSuccess -> do
-      setSGR [SetColor Foreground Vivid Green]
-      progPutStrLn config $ "Successfully compiled : " ++ exFilename
-      setSGR [Reset]
-      case exType of
-        CompileOnly -> removeDirectoryRecursive genDirPath >> return RunSuccess
-        UnitTests -> do
-          let execSpec = shell genExecutablePath
-          (_, execStdOut, execStdErr, execProcHandle) <- createProcess (execSpec { std_out = CreatePipe, std_err = CreatePipe })
-          execExit <- waitForProcess execProcHandle
-          case execExit of
-            ExitFailure code -> do
-              setSGR [SetColor Foreground Vivid Red]
-              progPutStrLn config $ "Tests failed on exercise : " ++ exFilename
-              case execStdErr of
-                Nothing -> return ()
-                Just h  -> hGetContents h >>= progPutStrLn config
-              case execStdOut of
-                Nothing -> return ()
-                Just h  -> hGetContents h >>= progPutStrLn config
-              setSGR [Reset]
-              removeDirectoryRecursive genDirPath
-              return TestFailed
-            ExitSuccess -> do
-              setSGR [SetColor Foreground Vivid Green]
-              progPutStrLn config $ "Successfully ran : " ++ exFilename
-              setSGR [Reset]
-              removeDirectoryRecursive genDirPath
-              return RunSuccess
-        Executable inputs outputPred -> do
-          let execSpec = shell genExecutablePath
-          (execStdIn, execStdOut, execStdErr, execProcHandle) <- createProcess
-            (execSpec { std_out = CreatePipe, std_err = CreatePipe, std_in = CreatePipe })
-          when (isJust execStdIn) $ forM_ inputs $ \i -> hPutStrLn (fromJust execStdIn) i
-          execExit <- waitForProcess execProcHandle
-          case execExit of
-            ExitFailure code -> do
-              setSGR [SetColor Foreground Vivid Red]
-              progPutStrLn config $ "Encountered error running exercise: " ++ exFilename
-              case execStdOut of
-                Nothing -> return ()
-                Just h  -> hGetContents h >>= progPutStrLn config
-              case execStdErr of
-                Nothing -> return ()
-                Just h  -> hGetContents h >>= progPutStrLn config
-              progPutStrLn config "Check the Sample Input and Sample Output in the file."
-              progPutStrLn config $ "Then try running it for yourself with 'haskellings exec" ++ haskellModuleName exFilename ++ "'."
-              setSGR [Reset]
-              removeDirectoryRecursive genDirPath
-              return TestFailed
-            ExitSuccess -> do
-              passes <- case execStdOut of
-                Nothing -> return (outputPred [])
-                Just h  -> (lines <$> hGetContents h) >>= (return . outputPred)
-              if passes
-                then do
-                  setSGR [SetColor Foreground Vivid Green]
-                  progPutStrLn config $ "Successfully ran : " ++ exFilename
-                  progPutStrLn config $ "You can run this code for yourself with 'haskellings exec " ++ haskellModuleName exFilename ++ "'."
-                  setSGR [Reset]
-                  removeDirectoryRecursive genDirPath
-                  return RunSuccess
-                else do
-                  setSGR [SetColor Foreground Vivid Red]
-                  progPutStrLn config $ "Unexpected output for exercise: " ++ exFilename
-                  progPutStrLn config "Check the Sample Input and Sample Output in the file."
-                  progPutStrLn config $ "Then try running it for yourself with 'haskellings exec " ++ haskellModuleName exFilename ++ "'."
-                  setSGR [Reset]
-                  removeDirectoryRecursive genDirPath
-                  return TestFailed
+      progPutStrLnSuccess config $ "Successfully ran : " ++ exFilename
+      return RunSuccess
 
-compileExercise_ :: ProgramConfig -> ExerciseInfo -> IO ()
-compileExercise_ config ex = void $ compileExercise config ex
+runExecutableExercise
+  :: ProgramConfig
+  -> FilePath
+  -> String
+  -> [String]
+  -> ([String] -> Bool)
+  -> IO RunResult
+runExecutableExercise config genExecutablePath exFilename inputs outputPred = do
+  let execSpec = shell genExecutablePath
+  (execStdIn, execStdOut, execStdErr, execProcHandle) <- createProcess
+    (execSpec { std_out = CreatePipe, std_err = CreatePipe, std_in = CreatePipe })
+  when (isJust execStdIn) $ forM_ inputs $ \i -> hPutStrLn (fromJust execStdIn) i
+  execExit <- waitForProcess execProcHandle
+  case execExit of
+    ExitFailure code -> withTerminalFailure $ do
+      progPutStrLn config $ "Encountered error running exercise: " ++ exFilename
+      case execStdOut of
+        Nothing -> return ()
+        Just h  -> hGetContents h >>= progPutStrLn config
+      case execStdErr of
+        Nothing -> return ()
+        Just h  -> hGetContents h >>= progPutStrLn config
+      progPutStrLn config "Check the Sample Input and Sample Output in the file."
+      progPutStrLn config $ "Then try running it for yourself with 'haskellings exec" ++ haskellModuleName exFilename ++ "'."
+      return TestFailed
+    ExitSuccess -> do
+      passes <- case execStdOut of
+        Nothing -> return (outputPred [])
+        Just h  -> (lines <$> hGetContents h) >>= (return . outputPred)
+      if passes
+        then withTerminalSuccess $ do
+          progPutStrLn config $ "Successfully ran : " ++ exFilename
+          progPutStrLn config $ "You can run this code for yourself with 'haskellings exec " ++ haskellModuleName exFilename ++ "'."
+          return RunSuccess
+        else withTerminalFailure $ do
+          progPutStrLn config $ "Unexpected output for exercise: " ++ exFilename
+          progPutStrLn config "Check the Sample Input and Sample Output in the file."
+          progPutStrLn config $ "Then try running it for yourself with 'haskellings exec " ++ haskellModuleName exFilename ++ "'."
+          return TestFailed
+
+-- TODO: This function is officially monstrous and needs to be refactored.
+compileAndRunExercise :: ProgramConfig -> ExerciseInfo -> IO RunResult
+compileAndRunExercise config exInfo@(ExerciseInfo exerciseName exDirectory exType _) = do
+  let (processSpec, genDirPath, genExecutablePath) = createExerciseProcess config exInfo
+  let exFilename = haskellFileName exerciseName
+  withDirectory genDirPath $ do
+    (_, _, procStdErr, procHandle) <- createProcess (processSpec { std_out = CreatePipe, std_err = CreatePipe })
+    exitCode <- waitForProcess procHandle
+    case exitCode of
+      ExitFailure code -> onCompileFailure config exFilename procStdErr
+      ExitSuccess -> do
+        progPutStrLnSuccess config $ "Successfully compiled : " ++ exFilename
+        case exType of
+          CompileOnly -> return RunSuccess
+          UnitTests -> runUnitTestExercise config genExecutablePath exFilename
+          Executable inputs outputPred -> runExecutableExercise config genExecutablePath exFilename inputs outputPred
+
+compileAndRunExercise_ :: ProgramConfig -> ExerciseInfo -> IO ()
+compileAndRunExercise_ config ex = void $ compileAndRunExercise config ex
 
 fileContainsNotDone :: FilePath -> IO Bool
 fileContainsNotDone fullFp = do

--- a/src/Watcher.hs
+++ b/src/Watcher.hs
@@ -25,7 +25,7 @@ processEvent :: ProgramConfig -> ExerciseInfo -> MVar () -> Event -> IO ()
 processEvent config exerciseInfo signalMVar _ = do
   progPutStrLn config $ "Running exercise: " ++ exerciseName exerciseInfo
   withFileLock fullFp config $ do
-    runResult <- compileExercise config exerciseInfo
+    runResult <- compileAndRunExercise config exerciseInfo
     case runResult of
       RunSuccess -> do
         isNotDone <- fileContainsNotDone fullFp
@@ -40,7 +40,7 @@ runExerciseWatch :: ProgramConfig -> [ExerciseInfo] -> IO ()
 runExerciseWatch config [] = progPutStrLn config "Congratulations, you've completed all the exercises!"
 runExerciseWatch config (firstEx : restExs) = do
   (runResult, isDone) <- withFileLock fullFp config $ do
-    runResult <- compileExercise config firstEx
+    runResult <- compileAndRunExercise config firstEx
     isDone <- not <$> fileContainsNotDone fullFp
     return (runResult, isDone)
   if runResult == RunSuccess && isDone

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -71,7 +71,7 @@ compileTests1 paths = before (compileBeforeHook paths exInfo "types1_bad.output"
       exit `shouldBe` CompileError
       isFailureOutput output
   where
-    exInfo = ExerciseInfo "Types1Bad" "types" False ""
+    exInfo = ExerciseInfo "Types1Bad" "types" CompileOnly ""
 
 compileTests2 :: (FilePath, FilePath) -> Spec
 compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output") $
@@ -80,7 +80,7 @@ compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output
       exit `shouldBe` RunSuccess
       isSuccessOutput output
   where
-    exInfo = ExerciseInfo "Types1Good" "types" False ""
+    exInfo = ExerciseInfo "Types1Good" "types" CompileOnly ""
 
 compileAndRunTestFail1 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion1_bad1.output") $
@@ -89,7 +89,7 @@ compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion
       exit `shouldBe` CompileError
       isFailureOutput output
   where
-    exInfo = ExerciseInfo "Recursion1Bad1" "recursion" True ""
+    exInfo = ExerciseInfo "Recursion1Bad1" "recursion" UnitTests ""
 
 compileAndRunTestFail2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion1_bad2.output") $
@@ -98,7 +98,7 @@ compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion
       isRunFailureOutput output
       exit `shouldBe` TestFailed
   where
-    exInfo = ExerciseInfo "Recursion1Bad2" "recursion" True ""
+    exInfo = ExerciseInfo "Recursion1Bad2" "recursion" UnitTests ""
 
 compileAndRunTestPass :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1_good.output") $
@@ -107,7 +107,7 @@ compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
   where
-    exInfo = ExerciseInfo "Recursion1Good" "recursion" True ""
+    exInfo = ExerciseInfo "Recursion1Good" "recursion" UnitTests ""
 
 compileAndRunTestPass2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion2.output") $
@@ -116,7 +116,7 @@ compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
   where
-    exInfo = ExerciseInfo "Recursion2" "recursion" True ""
+    exInfo = ExerciseInfo "Recursion2" "recursion" UnitTests ""
 
 
 
@@ -125,8 +125,8 @@ compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion
 
 watchTestExercises :: [ExerciseInfo]
 watchTestExercises =
-  [ ExerciseInfo "Types1" "watcher_types" False "What type should you fill in for the variable?"
-  , ExerciseInfo "Types2" "watcher_types" False "What type can you fill in for the tuple?"
+  [ ExerciseInfo "Types1" "watcher_types" CompileOnly "What type should you fill in for the variable?"
+  , ExerciseInfo "Types2" "watcher_types" CompileOnly "What type can you fill in for the tuple?"
   ]
 
 watchTests :: (FilePath, FilePath) -> Spec

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -149,7 +149,7 @@ compileAndExecFail1 paths = before (compileBeforeHook paths exInfo "io_bad1.outp
 
 compileAndExecFail2 :: (FilePath, FilePath) -> Spec
 compileAndExecFail2 paths = before (compileBeforeHook paths exInfo "io_bad1.output") $
-  describe "When running 'compileExercise' with a non-compiling executable exercise" $
+  describe "When running 'compileExercise' with a compiling executable exercise that doesn't pass." $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` TestFailed
       isExecFailureOutput output

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -40,7 +40,7 @@ compileBeforeHook (projectRoot, ghcPath) exInfo outFile = do
   outHandle <- openFile fullFp WriteMode
   packageDb <- findStackPackageDb
   let conf = ProgramConfig projectRoot ghcPath packageDb "/tests/exercises/" stdin outHandle stderr M.empty
-  resultExit <- compileExercise conf exInfo
+  resultExit <- compileAndRunExercise conf exInfo
   hClose outHandle
   programOutput <- readFile fullFp
   return (programOutput, resultExit)
@@ -96,7 +96,7 @@ isSuccessExecOutput output = do
 
 compileTests1 :: (FilePath, FilePath) -> Spec
 compileTests1 paths = before (compileBeforeHook paths exInfo "types1_bad.output") $
-  describe "When running 'compileExercise' with non-compiling file" $
+  describe "When running 'compileAndRunExercise' with non-compiling file" $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` CompileError
       isFailureOutput output
@@ -105,7 +105,7 @@ compileTests1 paths = before (compileBeforeHook paths exInfo "types1_bad.output"
 
 compileTests2 :: (FilePath, FilePath) -> Spec
 compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output") $
-  describe "When running 'compileExercise' with compiling file" $
+  describe "When running 'compileAndRunExercise' with compiling file" $
     it "Should indicate successful compilation and return a success exit code" $ \(output, exit) -> do
       exit `shouldBe` RunSuccess
       isSuccessOutput output
@@ -114,7 +114,7 @@ compileTests2 paths = before (compileBeforeHook paths exInfo "types1_good.output
 
 compileAndRunTestFail1 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion1_bad1.output") $
-  describe "When running 'compileExercise' with non-compiling and runnable file" $
+  describe "When running 'compileAndRunExercise' with non-compiling and runnable file" $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` CompileError
       isFailureOutput output
@@ -123,7 +123,7 @@ compileAndRunTestFail1 paths = before (compileBeforeHook paths exInfo "recursion
 
 compileAndRunTestFail2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion1_bad2.output") $
-  describe "When running 'compileExercise' with compiling but incorrect file" $
+  describe "When running 'compileAndRunExercise' with compiling but incorrect file" $
     it "Should indicate test failures and return a failing exit code" $ \(output, exit) -> do
       isRunFailureOutput output
       exit `shouldBe` TestFailed
@@ -132,7 +132,7 @@ compileAndRunTestFail2 paths = before (compileBeforeHook paths exInfo "recursion
 
 compileAndRunTestPass :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1_good.output") $
-  describe "When running 'compileExercise' with compiling and runnable file" $
+  describe "When running 'compileAndRunExercise' with compiling and runnable file" $
     it "Should indicate successful compilation and return a success exit code" $ \(output, exit) -> do
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
@@ -141,7 +141,7 @@ compileAndRunTestPass paths = before (compileBeforeHook paths exInfo "recursion1
 
 compileAndRunTestPass2 :: (FilePath, FilePath) -> Spec
 compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion2.output") $
-  describe "When running 'compileExercise' with compiling and runnable file that has a unit testing library" $
+  describe "When running 'compileAndRunExercise' with compiling and runnable file that has a unit testing library" $
     it "Should indicate successful compilation and return a success exit code" $ \(output, exit) -> do
       exit `shouldBe` RunSuccess
       isSuccessRunOutput output
@@ -150,7 +150,7 @@ compileAndRunTestPass2 paths = before (compileBeforeHook paths exInfo "recursion
 
 compileAndExecFail1 :: (FilePath, FilePath) -> Spec
 compileAndExecFail1 paths = before (compileBeforeHook paths exInfo "io_bad1.output") $
-  describe "When running 'compileExercise' with a non-compiling executable exercise" $
+  describe "When running 'compileAndRunExercise' with a non-compiling executable exercise" $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` CompileError
       isFailureOutput output
@@ -159,7 +159,7 @@ compileAndExecFail1 paths = before (compileBeforeHook paths exInfo "io_bad1.outp
 
 compileAndExecFail2 :: (FilePath, FilePath) -> Spec
 compileAndExecFail2 paths = before (compileBeforeHook paths exInfo "io_bad2.output") $
-  describe "When running 'compileExercise' with a compiling executable exercise that errors." $
+  describe "When running 'compileAndRunExercise' with a compiling executable exercise that errors." $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` TestFailed
       isExecRunFailureOutput output
@@ -168,7 +168,7 @@ compileAndExecFail2 paths = before (compileBeforeHook paths exInfo "io_bad2.outp
 
 compileAndExecFail3 :: (FilePath, FilePath) -> Spec
 compileAndExecFail3 paths = before (compileBeforeHook paths exInfo "io_bad3.output") $
-  describe "When running 'compileExercise' with a compiling executable exercise that doesn't pass the tests." $
+  describe "When running 'compileAndRunExercise' with a compiling executable exercise that doesn't pass the tests." $
     it "Should indicate failure to compile and return a failing exit code" $ \(output, exit) -> do
       exit `shouldBe` TestFailed
       isExecTestFailureOutput output
@@ -177,7 +177,7 @@ compileAndExecFail3 paths = before (compileBeforeHook paths exInfo "io_bad3.outp
 
 compileAndExecPass :: (FilePath, FilePath) -> Spec
 compileAndExecPass paths = before (compileBeforeHook paths exInfo "io_good.output") $
-  describe "When running 'compileExercise' with a passing executable exercise" $
+  describe "When running 'compileAndRunExercise' with a passing executable exercise" $
     it "Should indicate successful compilation and return a success exit code" $ \(output, exit) -> do
       exit `shouldBe` RunSuccess
       isSuccessExecOutput output

--- a/tests/exercises/io/IOBad1.hs
+++ b/tests/exercises/io/IOBad1.hs
@@ -1,0 +1,17 @@
+-- I AM NOT DONE
+
+main :: IO ()
+main = ???
+
+{-
+
+Sample Input:
+
+John
+
+Sample Output:
+
+Hello, please enter your name!
+Hello, John
+
+-}

--- a/tests/exercises/io/IOBad2.hs
+++ b/tests/exercises/io/IOBad2.hs
@@ -1,0 +1,20 @@
+-- I AM NOT DONE
+
+main :: IO ()
+main = do
+  putStrLn "Hello, please enter your name!"
+  name <- getLine
+  putStrLn name
+
+{-
+
+Sample Input:
+
+John
+
+Sample Output:
+
+Hello, please enter your name!
+Hello, John
+
+-}

--- a/tests/exercises/io/IOBad3.hs
+++ b/tests/exercises/io/IOBad3.hs
@@ -4,7 +4,7 @@ main :: IO ()
 main = do
   putStrLn "Hello, please enter your name!"
   name <- getLine
-  putStrLn undefined
+  putStrLn name
 
 {-
 

--- a/tests/exercises/io/IOGood.hs
+++ b/tests/exercises/io/IOGood.hs
@@ -1,0 +1,20 @@
+-- I AM NOT DONE
+
+main :: IO ()
+main = do
+  putStrLn "Hello, please enter your name!"
+  name <- getLine
+  putStrLn $ "Hello, " ++ name
+
+{-
+
+Sample Input:
+
+John
+
+Sample Output:
+
+Hello, please enter your name!
+Hello, John
+
+-}


### PR DESCRIPTION
Allows a new type of exercise - executable

In these exercises, a user will fill in the "main" function themselves. In `run` mode, we'll evaluate their program against a single set of inputs/outputs. In the new `exec` mode, users will be able to run the executable themselves to see its behavior on different inputs.

This involved substantial refactoring of the 'compileExercise' function to break it into more constituent parts. Also added some helpers for terminal printing and the like.