### PR TITLE
Make all exercises not compile to start

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Within the [exercises directory](https://github.com/MondayMorningHaskell/haskell
 
 This will run the [`Types1`](https://github.com/MondayMorningHaskell/haskellings/blob/master/exercises/basics/Types1.hs) exercise.
 
-Initially, exercises will not compile. You'll want to open the file, read the information at the top, and then fill in the code as indicated by the `TODO` comments.
+Initially, exercises will not compile. You'll want to open the file, read the information at the top, and then fill in the code as indicated by the `TODO` comments. You'll usually be replacing the question marks `???` with your function implementations and type declarations.
 
 You can re-run the exercise, and the output will let you know when you're done!
 
@@ -47,6 +47,26 @@ If you're stuck, each exercise also has a hint you can see by running `haskellin
 >> haskellings hint Types1
 Fill in appropriate type signatures for the expressions at the bottom.
 ```
+
+Sometimes you might want to compile and run code you've written for one function without filling in the rest. When this happens, you can usually replace the question marks `???` for function implementations with the phrase `undefined`. Using `undefined` lets your code compile, though that particular function won't run:
+
+```haskell
+-- BEFORE:
+subtract7 :: Int -> Int
+subtract7 = ???
+
+multiplyBy7 :: Int -> Int
+multiplyBy7 = ???
+
+-- AFTER:
+subtract7 :: Int -> Int
+subtract7 x = x - 7
+
+multiplyBy7 :: Int -> Int
+multiplyBy7 = undefined
+```
+
+For example, after making the above change, you'll be able to run the tests for the `subtract7` function. You'll still see errors while running the tests for `multiplyBy7`, but they will compile. Sometimes the implementation will start as `undefined` rather than `???`, in which case it's still your job to replace it!
 
 ## Using the Watcher
 

--- a/exercises/functions/Functions2.hs
+++ b/exercises/functions/Functions2.hs
@@ -40,16 +40,16 @@ Here are a few examples:
 -- Add the heads of the two inputs together. Return this as the first element
 -- of the tuple. Then you should also return the tail of each list.
 addHeads :: ([Int], [Int]) -> (Int, [Int], [Int])
-addHeads = undefined
+addHeads = ???
 
 -- Produce a new tuple containing the three *second* elements of each of
 -- the input tuples.
 takeSeconds :: (Int, Int) -> (Int, Int) -> (Int, Int) -> (Int, Int, Int)
-takeSeconds = undefined
+takeSeconds = ???
 
 -- Capitalize each of the three characters
 capitalize :: (Char, Char, Char) -> (Char, Char, Char)
-capitalize = undefined
+capitalize = ???
 
 -- Testing Code, You can ignore this:
 main :: IO ()

--- a/exercises/functions/Functions3.hs
+++ b/exercises/functions/Functions3.hs
@@ -30,7 +30,7 @@ multiplyBy3Add5 = multiplyBy3AndAdd 5
 -- Then multiply the second elements together as well.
 -- Add the results.
 multiplyAndAdd :: (Int, Int) -> (Int, Int) -> Int
-multiplyAndAdd = undefined
+multiplyAndAdd = ???
 
 -- Take a tuple of two Ints.
 -- Multiply the first value by 3 and the second by 4. Then add the results.

--- a/exercises/functions/Functions5.hs
+++ b/exercises/functions/Functions5.hs
@@ -41,15 +41,15 @@ the front of a list:
 -- This should take any boolean value and return True!
 -- (There are two easy ways to do this, try both!)
 trueSink :: Bool -> Bool
-trueSink = undefined
+trueSink = ???
 
 -- This should take any boolean value and return False!
 falseSink :: Bool -> Bool
-falseSink = undefined
+falseSink = ???
 
 -- Return True if and only if all three inputs are true.
 tripleAnd :: Bool -> Bool -> Bool -> Bool
-tripleAnd = undefined
+tripleAnd = ???
 
 -- Take two lists. Remove the first element from each list and add them together.
 -- The first output should be like the first list except with this new sum at the
@@ -57,7 +57,7 @@ tripleAnd = undefined
 -- original second input.
 -- addToFirstList [1, 2] [9, 8] = ([10, 2], [8])
 addToFirstList :: [Int] -> [Int] -> ([Int], [Int])
-addToFirstList = undefined
+addToFirstList = ???
 
 -- Testing Code
 main :: IO ()

--- a/exercises/functions/Functions6.hs
+++ b/exercises/functions/Functions6.hs
@@ -36,11 +36,11 @@ doubleList xs = map double xs
 
 -- Flip the boolean value of each input
 flipBools :: [Bool] -> [Bool]
-flipBools input = undefined
+flipBools input = ???
 
 -- Uppercase all the letters in this word!
 capitalizeWord :: String -> String
-capitalizeWord input = undefined
+capitalizeWord input = ???
 
 -- TODO: Create your own higher order function, doubleAndApply.
 -- The input function should take a single integer

--- a/exercises/lists/Lists1.hs
+++ b/exercises/lists/Lists1.hs
@@ -60,15 +60,15 @@ foldr min 9999 [5, 7, 2, 9, 1]
 -- higher order helper functions instead!
 
 addMod3Is2 :: [Int] -> [Int]
-addMod3Is2 = undefined
+addMod3Is2 = ???
 
 sumList :: [Int] -> Int
-sumList = undefined
+sumList = ???
 
 -- Return true if every element is 'True'!
 -- (The empty list should return 'True'!)
 allTrue :: [Bool] -> Bool
-allTrue bs = undefined
+allTrue bs = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Lists1" $

--- a/exercises/lists/Lists2.hs
+++ b/exercises/lists/Lists2.hs
@@ -49,11 +49,11 @@ cycle [1, 2, 3, 4] -- < [1, 2, 3, 4, 1, 2, 3, 4, 1 ...]
 -- Given a particular number, give a list of the numbers starting
 -- there and counting down by 5 until you get to 0.
 countdownBy5 :: Word -> [Word]
-countdownBy5 = undefined
+countdownBy5 = ???
 
 -- Given a particular Int, create a list with 100 copies of it.
 give100 :: Int -> [Int]
-give100 = undefined
+give100 = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Lists2" $

--- a/exercises/lists/Lists3.hs
+++ b/exercises/lists/Lists3.hs
@@ -50,12 +50,12 @@ shortWords = ["HELLO", "BYE", "CIAO"]
 
 -- Implement addMod3Is2, except now use a list comprehension.
 addMod3Is2 :: [Int] -> [Int]
-addMod3Is2 = undefined
+addMod3Is2 = ???
 
 -- Take every pairwise product of the numbers, as long as their
 -- sum is less than 30.
 smallPairwiseProducts :: [Int] -> [Int] -> [Int]
-smallPairwiseProducts = undefined
+smallPairwiseProducts = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Lists3" $

--- a/exercises/lists/Lists4.hs
+++ b/exercises/lists/Lists4.hs
@@ -27,13 +27,13 @@ zip [1, 2, 3] ["Hi", "Bye"] = [(1, "Hi"), (2, "Bye")]
 -- return tuples containing the sum, product, and difference of each pair.
 -- sumProductDifference [4, 3] [1, 2] = [(5, 4, 3), (5, 6, 1)]
 sumProductDifference :: [Int] -> [Int] -> [(Int, Int, Int)]
-sumProductDifference = undefined
+sumProductDifference = ???
 
 -- Given a list of strings, make a new list where each String has been
 -- appended with its index within the list.
 -- addIndices ["Hello", "Bye"] = ["Hello0", "Bye1"]
 addIndices :: [String] -> [String]
-addIndices = undefined
+addIndices = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Lists4" $

--- a/exercises/monads/Applicatives.hs
+++ b/exercises/monads/Applicatives.hs
@@ -65,18 +65,18 @@ safeSquareRoot x = if x < 0 then Nothing else Just (sqrt x)
 -- Return the sum of the square roots of the two inputs, using
 -- 'safeSquareRoot' to check for negatives.
 sumOfSquareRoots :: Double -> Double -> Maybe Double
-sumOfSquareRoots = undefined
+sumOfSquareRoots = ???
 
 -- Generate all combinations of sums between the first list and the second list.
 -- (avoid using a list comprehension)
 generateSums :: [Int] -> [Int] -> [Int]
-generateSums = undefined
+generateSums = ???
 
 -- Given a list of operations and two lists, generate all combinations of
 -- those operations with each pair of numbers from the two lists.
 -- generateAllResults [(+), (*)] [1, 2] [3, 4] -> [4, 5, 5, 6, 3, 4, 6, 8]
 generateAllResults :: [Int -> Int -> Int] -> [Int] -> [Int] -> [Int]
-generateAllResults = undefined
+generateAllResults = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Applicatives" $

--- a/exercises/monads/Monads1.hs
+++ b/exercises/monads/Monads1.hs
@@ -67,13 +67,13 @@ multiplyIfSmall y x = if x < 9.5 then Just (y * x) else Nothing
 -- sqrtAndMultiply 25.0 = Just 50.0
 -- sqrtAndMultiply 121.0 = Nothing
 sqrtAndMultiply :: Double -> Maybe Double
-sqrtAndMultiply = undefined
+sqrtAndMultiply = ???
 
 -- Given a list of inputs, produce a new list that adds 1, 2, and 3 to each input
 -- and then for the final result, also includes the negation of every input.
 -- addAndNegate [1, 2] -> [2, -2, 3, -3, 4, -4, 3, -3, 4, -4, 5, -5]
 addAndNegate :: [Int] -> [Int]
-addAndNegate = undefined
+addAndNegate = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Monads1" $

--- a/exercises/monads/Monads2.hs
+++ b/exercises/monads/Monads2.hs
@@ -82,16 +82,16 @@ multiplyIfSmall y x = if x < 9.5 then Just (y * x) else Nothing
 -- Re-implement them all now using do-syntax!
 
 sumOfSquareRoots :: Double -> Double -> Maybe Double
-sumOfSquareRoots = undefined
+sumOfSquareRoots = ???
 
 generateAllResults :: [Int -> Int -> Int] -> [Int] -> [Int] -> [Int]
-generateAllResults = undefined
+generateAllResults = ???
 
 sqrtAndMultiply :: Double -> Maybe Double
-sqrtAndMultiply = undefined
+sqrtAndMultiply = ???
 
 addAndNegate :: [Int] -> [Int]
-addAndNegate = undefined
+addAndNegate = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Monads1" $

--- a/exercises/monads/Monads3.hs
+++ b/exercises/monads/Monads3.hs
@@ -77,7 +77,7 @@ add2AndShow = do
 -- result on the original int as well as twice it's value!
 -- runReader add2AndShowDouble 3 -> "(5,8)"
 add2AndShowDouble :: Reader Int String
-add2AndShowDouble = undefined
+add2AndShowDouble = ???
 
 data User = User
   { userEmail :: String
@@ -89,19 +89,19 @@ data User = User
 
 -- Validate that the entered password is equal to the stored user's password.
 validateAccount :: String -> String -> Reader User Bool
-validateAccount = undefined
+validateAccount = ???
 
 -- Given a user, display the lines of a "profile page" of the form:
 -- Name: {name}
 -- Age: {age}
 -- Bio: {bio}
 displayProfile :: Reader User [String]
-displayProfile = undefined
+displayProfile = ???
 
 -- Given a User, and the entered credentials, return their profile
 -- string if the authentication is valid, or otherwise return nothing.
 authAndDisplayProfile :: User -> (String, String) -> Maybe [String]
-authAndDisplayProfile = undefined
+authAndDisplayProfile = ???
 
 -- Test Code
 

--- a/exercises/monads/Monads4.hs
+++ b/exercises/monads/Monads4.hs
@@ -67,19 +67,19 @@ instance Show Op where
 -- its cost to the monad (using 'opCost' above).
 -- (If the input to 'Sqrt' is negative, just return the original value)
 applyOpCount :: Op -> Double -> Writer IntAdd Double
-applyOpCount = undefined
+applyOpCount = ???
 
 -- Now apply a series of operations to an input value using the 'Writer' monad!
 applyAndCountOperations :: [Op] -> Double -> (Double, IntAdd)
-applyAndCountOperations = undefined
+applyAndCountOperations = ???
 
 -- Do the same as above, except instead of counting the cost, log the
 -- string associated with 'showing' the operation.
 applyOpLog :: Op -> Double -> Writer [String] Double
-applyOpLog = undefined
+applyOpLog = ???
 
 applyAndLogOperations :: [Op] -> Double -> (Double, [String])
-applyAndLogOperations = undefined
+applyAndLogOperations = ???
 
 -- Test Code
 

--- a/exercises/monads/Monads5.hs
+++ b/exercises/monads/Monads5.hs
@@ -73,25 +73,25 @@ instance Show Op where
 -- instead of the Writer monad! Notice however, that you do not
 -- need a 'Monoid' instance for the "IntAdd" state!
 applyOpCount :: Op -> Double -> State IntAdd Double
-applyOpCount = undefined
+applyOpCount = ???
 
 applyAndCountOperations :: [Op] -> Double -> (Double, IntAdd)
-applyAndCountOperations = undefined
+applyAndCountOperations = ???
 
 applyOpLog :: Op -> Double -> State [String] Double
-applyOpLog = undefined
+applyOpLog = ???
 
 applyAndLogOperations :: [Op] -> Double -> (Double, [String])
-applyAndLogOperations = undefined
+applyAndLogOperations = ???
 
 -- Now write these in a simpler way, where the 'State' is the
 -- Double itself that you are tracking with the operations.
 -- This spares you from needing to track it as a separate input!
 applyOpSimple :: Op -> State Double ()
-applyOpSimple = undefined
+applyOpSimple = ???
 
 applySimpleOperations :: [Op] -> Double -> Double
-applySimpleOperations = undefined
+applySimpleOperations = ???
 
 -- Test Code
 

--- a/exercises/recursion/Recursion1.hs
+++ b/exercises/recursion/Recursion1.hs
@@ -48,7 +48,7 @@ quotient dividend divisor = if dividend < divisor
 -- factorial 3 = 6 -- (1 * 2 * 3)
 -- ...
 factorial :: Int -> Int
-factorial = undefined
+factorial = ???
 
 -- Calculate the 'specialDistance' to 1, according to these rules:
 -- The distance from 1 to itself is 0
@@ -57,7 +57,7 @@ factorial = undefined
 -- If the input n is odd, add 1 to the distance to 3n + 1.
 --  NOTE: The actual library function for integer division is 'quot'.
 specialDistance :: Word -> Word
-specialDistance = undefined
+specialDistance = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Recusion1" $

--- a/exercises/recursion/Recursion2.hs
+++ b/exercises/recursion/Recursion2.hs
@@ -41,12 +41,12 @@ sumList (a : as) = a + sumList as -- < RECURSIVE CASE
 -- Then add 3 to each of them!
 -- addMod3Is2 [2, 3, 4, 8] = [5, 10]
 addMod3Is2 :: [Int] -> [Int]
-addMod3Is2 = undefined
+addMod3Is2 = ???
 
 -- Take only the 'even' index elements of the list (the second, fourth, sixth, etc.)
 -- evens [1, 5, 7, 0, 3, 2, 2, 3] = [5, 0, 2, 3]
 evens :: [Int] -> [Int]
-evens = undefined
+evens = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Recusion2" $

--- a/exercises/recursion/Recursion3.hs
+++ b/exercises/recursion/Recursion3.hs
@@ -31,7 +31,7 @@ sumList xs = sumListTail xs 0 -- < Initial accumulator is 0
 -- Write a tail-recursive function to reverse the list!
 -- (Note: In real code, you can rely on the 'reverse' library function)
 reverseList :: [a] -> [a]
-reverseList = undefined
+reverseList = ???
 
 -- Given a list, return a tuple of two sub-lists.
 -- The first is the "even" elements like you did in the last exercise!
@@ -39,7 +39,7 @@ reverseList = undefined
 -- Do this tail recursively!
 -- evenOdds [1, 5, 7, 0, 3, 2, 2, 3] = ([5, 0, 2, 3], [1, 7, 3, 2])
 evenOdds :: [a] -> ([a], [a])
-evenOdds = undefined
+evenOdds = ???
 
 main :: IO ()
 main = defaultMain $ testGroup "Recusion3" $

--- a/exercises/recursion/Recursion4.hs
+++ b/exercises/recursion/Recursion4.hs
@@ -54,7 +54,7 @@ data BinaryTree = BinaryTree
 -- Take the sum of all the values in a BinaryTree!
 -- You'll need to make multiple recursive calls at once!
 sumTree :: BinaryTree -> Int
-sumTree = undefined
+sumTree = ???
 
 -- Determine if your tree is a valid Binary Search Tree (BST)
 -- For every ValueNode in the tree:
@@ -62,7 +62,7 @@ sumTree = undefined
 --   2. All elements in its right subtree are larger than the value at the node.
 -- You might want a helper that takes two 'bounding' elements in addition to a subtree.
 isValidBst :: BinaryTree -> Bool
-isValidBst = undefined
+isValidBst = ???
 
 tree1 :: BinaryTree
 tree1 = ValueNode 8

--- a/exercises/syntax/Syntax1.hs
+++ b/exercises/syntax/Syntax1.hs
@@ -39,7 +39,7 @@ multiplicationFunc x = if mod x 3 == 0
 -- TODO: Fill in these functions!
 -- Of the two inputs, return how many are "True"
 countTrue :: Bool -> Bool -> Int
-countTrue b1 b2 = undefined
+countTrue b1 b2 = ???
 
 -- What is the type signature of this function?
 evalInput :: ???

--- a/exercises/syntax/Syntax2.hs
+++ b/exercises/syntax/Syntax2.hs
@@ -38,13 +38,13 @@ Note: The cases are evaluated in the order they are listed.
 
 -- Rewrite 'countTrue', except this it takes 3 inputs, so use guards!
 countTrue :: Bool -> Bool -> Bool -> Int
-countTrue = undefined
+countTrue = ???
 
 -- Return a string representation of the (positive) input number,
 -- from 0 = "Zero" up through 5 = "Five".
 -- If it's larger than 5, return "Too many!"
 numberString :: Word -> String
-numberString = undefined
+numberString = ???
 
 -- Testing Code
 main :: IO ()

--- a/exercises/syntax/Syntax3.hs
+++ b/exercises/syntax/Syntax3.hs
@@ -35,14 +35,14 @@ countTrue _ _ = 1
 
 -- Rewrite numberString from last time, but use a pattern match instead of guards!
 numberString :: Word -> String
-numberString = undefined
+numberString = ???
 
 -- If the input number is 0-3, return the first, corresponding number of elements
 -- in the list. e.g. takeN 0 [1,2,3,4] = [], takeN 2 [1,2,3,4] = [1,2]
 -- If the input number is larger, return the whole list.
 -- You can assume the input has at least 4 elements.
 takeN :: Word -> [Int] -> [Int]
-takeN = undefined
+takeN = ???
 
 -- Testing Code
 main :: IO ()

--- a/exercises/syntax/Syntax4.hs
+++ b/exercises/syntax/Syntax4.hs
@@ -44,7 +44,7 @@ evalList mylist = case myList of
 -- sum of the first elements. But if there are at least 4 elements,
 -- you can simply return 10.
 evalList :: Bool -> [Int] -> Int
-evalList = undefined
+evalList = ???
 
 -- Testing Code
 main :: IO ()

--- a/exercises/syntax/Syntax5.hs
+++ b/exercises/syntax/Syntax5.hs
@@ -54,14 +54,14 @@ badSum x y z = prod1 + prod2 + prod3 + prod4
 
 -- Take the sum of each pairwise product of inputs.
 sumPairProducts :: (Int, Int, Int, Int, Int, Int) -> Int
-sumPairProducts = undefined
+sumPairProducts = ???
 
 -- Take the sum of corresponding elements of the tuples, but only include each
 -- pair when the corresponding bool is true.
 -- e.g. sumTuples (True, False, False) (1, 2, 3) (4, 5, 6) = 5
 --      sumTuples (True, False, True)  (1, 2, 3) (4, 5, 6) = 14
 sumTuples :: (Bool, Bool, Bool) -> (Int, Int, Int) -> (Int, Int, Int) -> Int
-sumTuples = undefined
+sumTuples = ???
 
 -- Testing Code
 main :: IO ()

--- a/exercises/syntax/Syntax6.hs
+++ b/exercises/syntax/Syntax6.hs
@@ -42,14 +42,14 @@ badSum x y z = prod1 + prod2 + prod3 + prod4
 
 -- Take the sum of each pairwise product of inputs.
 sumPairProducts :: (Int, Int, Int, Int, Int, Int) -> Int
-sumPairProducts = undefined
+sumPairProducts = ???
 
 -- Take the sum of corresponding elements of the tuples, but only include each
 -- pair when the corresponding bool is true.
 -- e.g. sumTuples (True, False, False) (1, 2, 3) (4, 5, 6) = 5
 --      sumTuples (True, False, True)  (1, 2, 3) (4, 5, 6) = 14
 sumTuples :: (Bool, Bool, Bool) -> (Int, Int, Int) -> (Int, Int, Int) -> Int
-sumTuples = undefined
+sumTuples = ???
 
 -- Testing Code
 main :: IO ()


### PR DESCRIPTION
Make exercises non-compilable to start

This is preferable behavior so that the user doesn't see a big pile of failed tests without even knowing what exercise they're working on.