### PR TITLE
Config Tweaks

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -23,7 +23,6 @@ main = do
           Left NoGhcError -> putStrLn $ "Couldn't find " ++ ghcVersion
           Left NoStackPackageDbError -> putStrLn "Couldn't find an appropriate stack package DB!"
           Right paths -> do
-            packageDb <- findStackPackageDb
             let config = uncurry3 ProgramConfig paths mainProjectExercisesDir stdin stdout stderr empty
             runCommand config (tail args) (head args)
 

--- a/src/RunCommands.hs
+++ b/src/RunCommands.hs
@@ -70,17 +70,20 @@ runConfigure = do
   projectRoot' <- findProjectRoot
   case projectRoot' of
     Nothing -> putStrLn "Could not find project root. Please move the repository so that it is somewhere within the 'home' directory on your system."
-    Just projectRoot -> do
-      putStrLn "Please enter GHC Path (or leave blank for default): "
-      ghc <- getLine
-      putStrLn "Please enter Stack package DB path (or leave blank): "
-      stackPath <- getLine
-      let configPath = projectRoot `pathJoin` configFileName
-      alreadyExists <- doesFileExist configPath
-      when alreadyExists $ removeFile configPath
-      let config = BaseConfig
-                     (if null ghc then Nothing else Just ghc)
-                     (if null stackPath then Nothing else Just stackPath)
-      if null ghc && null stackPath
-        then putStrLn "No configuration information given, will rely on defaults."
-        else encodeFile configPath config >> putStrLn ("Saved configuration to " ++ configPath)
+    Just projectRoot -> runConfigureWithProjectRoot projectRoot
+
+runConfigureWithProjectRoot :: FilePath -> IO ()
+runConfigureWithProjectRoot projectRoot = do
+  putStrLn "Please enter GHC Path (or leave blank for default): "
+  ghc <- getLine
+  putStrLn "Please enter Stack package DB path (or leave blank): "
+  stackPath <- getLine
+  let configPath = projectRoot `pathJoin` configFileName
+  alreadyExists <- doesFileExist configPath
+  when alreadyExists $ removeFile configPath
+  let config = BaseConfig
+                 (if null ghc then Nothing else Just ghc)
+                 (if null stackPath then Nothing else Just stackPath)
+  if null ghc && null stackPath
+    then putStrLn "No configuration information given, will rely on defaults."
+    else encodeFile configPath config >> putStrLn ("Saved configuration to " ++ configPath)


### PR DESCRIPTION
1. Remove unnecessary call of finding stack package DB
2. Expose base paths function so it can use a different project root
3. Expose runConfigure so it can use a different project root