### PR TITLE
Addresses issue #38 Typeclasses3 InterestRate deriving Read issue

### DIFF
--- a/exercises/typeclasses/Typeclasses3.hs
+++ b/exercises/typeclasses/Typeclasses3.hs
@@ -73,7 +73,7 @@ main = defaultMain $ testGroup "Typeclasses3" $
       [Adult1 "John" "Smith" 45, Adult1 "Thomas" "Allen" 46, Adult1 "Zach" "Whittaker" 31]
   , testCase "Ordering Adults 2" $ sort [Adult2 "Zach" "Whittaker" 31, Adult2 "John" "Smith" 45, Adult2 "Thomas" "Allen" 46] @?=
       [Adult2 "Thomas" "Allen" 46, Adult2 "John" "Smith" 45, Adult2 "Zach" "Whittaker" 31]
-  , testCase "Read Interest Rate" $ map read ["0.5", "0.3", "0.788"] @?= [InterestRate 0.5, InterestRate 0.3, InterestRate 0.788]
+  , testCase "Read Interest Rate" $ map read ["InterestRate 0.5", "InterestRate 0.3", "InterestRate 0.788"] @?= [InterestRate 0.5, InterestRate 0.3, InterestRate 0.788]
   , testCase "Higher Interest Rate 1" $ returnHigherInterestRate ("John", 0.3) ("Tom", 0.03) @?=
       "'\"John\"' has a higher interest rate!"
   , testCase "Higher Interest Rate 1" $ returnHigherInterestRate (Adult1 "John" "Smith" 15, InterestRate 0.07) (Adult1 "Tom" "Allen" 18, InterestRate 0.1) @?=


### PR DESCRIPTION
The unit test on the Typeclasses3 exercise was failing when deriving Read (see issue #38 ).
This is because the derived implementation expects the Constructor to be included in the String.

As far as I know, deriving the Read instance such that it would pass the unit test would require enabling the Language extensions:
`{-# LANGUAGE GeneralizedNewtypeDeriving, DerivingStrategies #-}`
and then deriving it like so:
`deriving newtype Read`
This solution seems to be beyond the scope of the exercise.

There might be other ways of solving the exercise that I am not aware of.

Here, I have modified the unit test to make it pass when deriving the Read instance in the usual way.