### PR TITLE
Use broader predicate for GHC dir

### DIFF
--- a/src/Config.hs
+++ b/src/Config.hs
@@ -187,10 +187,15 @@ findGhc = do
       results <- forM nextDirs $ \subPath -> do
         let fullPath = ghcSearchDir `pathJoin` subPath
         subContents <- safeListDirectory fullPath
-        return $ fmap (pathJoin fullPath) (find (==ghcVersion) subContents)
+        return $ fmap (pathJoin fullPath) (find ghcPred subContents)
       case catMaybes results of
         []       -> return Nothing
         (fp : _) -> return $ Just (fp `pathJoin` "bin" `pathJoin` "ghc")
+
+-- Determine a directory is a valid "ghc" directory.
+-- It must start with "ghc" and end with our version number.
+ghcPred :: FilePath -> Bool
+ghcPred path = isPrefixOf "ghc" (basename path) && isSuffixOf ghcVersionNumber path
 
 findStackPackageDb :: IO (Maybe FilePath)
 findStackPackageDb = do

--- a/tests/UnitTests.hs
+++ b/tests/UnitTests.hs
@@ -93,6 +93,8 @@ fpBFSTests testsRoot = testGroup "fpBFS Tests"
       fpBFS pred2 (S.singleton testsRoot) `shouldReturn` Just (testsRoot `pathJoin` actual2)
   , testCase "fpBFS 3" $
       fpBFS pred3 (S.singleton testsRoot) `shouldReturn` Nothing
+  , testCase "fpBFS 4" $
+      fpBFS (return . ghcPred) (S.singleton root3) `shouldReturn` Just (testsRoot `pathJoin` actual3)
   ]
   where
     pred1 fp = return ("ghc-8.8.4" `isSuffixOf` fp)
@@ -100,6 +102,8 @@ fpBFSTests testsRoot = testGroup "fpBFS Tests"
     pred3 fp = return ("ghc-8.3.4" `isSuffixOf` fp)
     actual1 = "directory_tests" `pathJoin` "test1" `pathJoin` "linux-x86_64-ghc-8.8.4"
     actual2 = "directory_tests" `pathJoin` "test2" `pathJoin` "windows-x86_64-ghc-8.6.2"
+    root3   = testsRoot `pathJoin` "directory_tests" `pathJoin` "test3"
+    actual3 = "directory_tests" `pathJoin` "test3" `pathJoin` "ghc-tinfo6-8.8.4"
 
 snapshotPackagePredicateTests :: FilePath -> TestTree
 snapshotPackagePredicateTests testsRoot = testGroup "snapshotPackagePredicate Tests"


### PR DESCRIPTION
Address https://github.com/MondayMorningHaskell/haskellings/issues/40.

Makes the GHC predicate more flexible. Instead of requiring the directory to be exactly `ghc-8.8.4`, we permit any directory that starts with `ghc` and ends with the version number `8.8.4`.