### PR TITLE
Add buildInput dependency to set ghc path in shell.nix

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -3,11 +3,12 @@
 pkgs.mkShell {
   buildInputs = with pkgs; [ 
     haskell.compiler.ghc884
+    which
     (import ./default.nix { inherit pkgs compiler; })
   ];
 
   shellHook = ''
-    __GHCPATH=$(echo $(whereis ghc) | sed 's/^....//')
+    __GHCPATH=$(echo $(which ghc))
     echo "ghc_path: $__GHCPATH" > config.yaml 
   '';
 }


### PR DESCRIPTION
Current shell.nix requires `whereis` (and hence is not working in a pure nix-shell) and the sed command yielded faulty output on my linux machine (not sure if that's a macOS commandline tools thing or not).
By adding the slightly more fitting tool `which` as a depdendency and using haskellings worked for me