### PR TITLE
Update versions and package commit for nix files

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,2 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/34f85de51bbc74595e63b22ee089adbb31f7c7a2.tar.gz") {}, compiler ? "ghc884" }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz") {}, compiler ? "ghc8104" }:
 pkgs.pkgs.haskell.packages.${compiler}.callPackage ./haskellings.nix { }

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,8 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/34f85de51bbc74595e63b22ee089adbb31f7c7a2.tar.gz") {}, compiler ? "ghc884" }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz") {}, compiler ? "ghc8104" }:
 
 pkgs.mkShell {
   buildInputs = with pkgs; [ 
-    haskell.compiler.ghc884
+    haskell.compiler.ghc8104
     (import ./default.nix { inherit pkgs compiler; })
   ];
 


### PR DESCRIPTION
I upgraded the Stack Resolver to 18.4 with GHC 8.10.4 in this PR: https://github.com/MondayMorningHaskell/haskellings/pull/44

However, Nix is still configured to use GHC 8.8.4. This upgrades the compiler and uses a more recent package commit, since the tests for `time-compat` were failing when using 8.10.4 with the previous package.