### PR TITLE
Use GHC 8.10.7 for basic M1 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: fpco/stack-build:lts-16.16
+      - image: fpco/stack-build:lts-18.23
     steps:
       - checkout
       - restore_cache:

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,2 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz") {}, compiler ? "ghc8104" }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/6c4b9f1a2fd761e2d384ef86cff0d208ca27fdca.tar.gz") {}, compiler ? "ghc8107" }:
 pkgs.pkgs.haskell.packages.${compiler}.callPackage ./haskellings.nix { }

--- a/haskellings.nix
+++ b/haskellings.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "haskellings";
-  version = "0.9.0.0";
+  version = "0.9.1.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                haskellings
-version:             0.9.0.0
+version:             0.9.2.0
 github:              "MondayMorningHaskell/haskellings"
 license:             BSD3
 author:              "James Bowen"

--- a/shell.nix
+++ b/shell.nix
@@ -1,14 +1,14 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/7e9b0dff974c89e070da1ad85713ff3c20b0ca97.tar.gz") {}, compiler ? "ghc8104" }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/6c4b9f1a2fd761e2d384ef86cff0d208ca27fdca.tar.gz") {}, compiler ? "ghc8107" }:
 
 pkgs.mkShell {
-  buildInputs = with pkgs; [ 
-    haskell.compiler.ghc8104
+  buildInputs = with pkgs; [
+    haskell.compiler.ghc8107
     which
     (import ./default.nix { inherit pkgs compiler; })
   ];
 
   shellHook = ''
     __GHCPATH=$(echo $(which ghc))
-    echo "ghc_path: $__GHCPATH" > config.yaml 
+    echo "ghc_path: $__GHCPATH" > config.yaml
   '';
 }

--- a/src/Haskellings/Constants.hs
+++ b/src/Haskellings/Constants.hs
@@ -36,16 +36,16 @@ import           System.Environment
 -- | The GHC version currently used by Haskellings. We use this
 --   to locate the appropriate GHC executable.
 ghcVersion :: String
-ghcVersion = "ghc-8.10.4"
+ghcVersion = "ghc-8.10.7"
 
 -- | The version number, isolated from any prefix. Also helps in
 --   finding certain directories.
 ghcVersionNumber :: String
-ghcVersionNumber = "8.10.4"
+ghcVersionNumber = "8.10.7"
 
 -- | The current Haskellings program version.
 haskellingsVersion :: String
-haskellingsVersion = "0.9.0.0"
+haskellingsVersion = "0.9.1.0"
 
 -- | The project root directory name. We need to find the project root
 --   in order to locate the exercises.

--- a/stack.yaml
+++ b/stack.yaml
@@ -17,7 +17,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-18.4
+resolver: lts-18.23
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 585817
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/4.yaml
-    sha256: ea3a318eafa9e9cc56bfbe46099fd0d54d32641ab7bbe1d182ed8f5de39f804c
-  original: lts-18.4
+    size: 587819
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/23.yaml
+    sha256: 7f69bb29a57495586e7e3ed31ecc59c0d2c959cb23bd52b71ca676f254c9beb1
+  original: lts-18.23


### PR DESCRIPTION
I'd like the help of anyone with M1 hardware and Haskell knowledge. I was trying to address issue #63 but in all honesty, I'm out of my depth.

The `haskellings` binary is successfully compiling, but any commands (but `help`) will hang, and the memory consumption for the process will start increasing. So far only M1 machines are affected. (It works well on my Linux x64 machine).

EDIT:
 So it does not hang, but it is hella slow (surely because ghc 8.10.7 support for AArch64 is basic (not native)):

 running `haskellings version` command on M1:
```
→ time /nix/store/n3cajvdc6iklh5kcqs7ih6brpydnkj6a-haskellings-0.9.1.0/bin/haskellings version                                                                                                    [94c7336]
0.9.1.0
 version  52.08s user 106.05s system 255% cpu 1:01.89 total
```

running `haskellings version` command on my linux:
```
[nix-shell:~/Code/Perso/Haskell/haskellings]$ time /nix/store/wps8lj22p54g1iz1hwb1nldyywxl7vbb-haskellings-0.9.1.0/bin/haskellings version
0.9.1.0

real	0m0.163s
user	0m1.333s
sys	0m1.355s
```