### PR TITLE
fix(issue66): trailing whitespaces in exercises files removed

### DIFF
--- a/exercises/basics/Expressions.hs
+++ b/exercises/basics/Expressions.hs
@@ -2,7 +2,7 @@ module Expressions where
 
 -- I AM NOT DONE
 
-{- 
+{-
 - In Haskell, you can define *expressions* by taking a name and using the
   "equals" sign to assign it a value. See how we do this with
   "expression1" and "expression2" below.
@@ -19,7 +19,7 @@ expression3 = ???
 
 expression4 = ???
 
-{- 
+{-
 - Haskell expression aren't "variables" like you might have in other languages.
   Once a value is assigned, we can't change it later. Thus there can be only
   one definition for each name.

--- a/exercises/data/Data5.hs
+++ b/exercises/data/Data5.hs
@@ -31,7 +31,7 @@ login :: String -> String -> LoginResult
 - It's not 100% clear which strings we should enter.
   A password? An API Key? An email? A username?
   We can make this clearer like so;
-  
+
 type Username = String
 type Password = String
 

--- a/exercises/data/Data6.hs
+++ b/exercises/data/Data6.hs
@@ -54,7 +54,7 @@ newtype Username = Username { unUsername :: String }
 
 -}
 
--- TODO: There are a few inaccuracies in this code, even though it compiles! 
+-- TODO: There are a few inaccuracies in this code, even though it compiles!
 --       Turn these type synonyms into newtypes so they cause compilation errors.
 --       Then fix the errors!
 

--- a/exercises/functions/Curry.hs
+++ b/exercises/functions/Curry.hs
@@ -6,14 +6,14 @@ import Test.Tasty.HUnit
 {-
 - In Haskell, functions that take more than one argument are usually
   *curried*, meaning the function takes one argument and returns a new function
-  that takes the second argument. 
+  that takes the second argument.
 
 - This is also reflected in the type signature of multi-argument functions:
 
 f :: String -> Int -> Bool
 
-- In the above example, f is a function that takes a String and returns 
-  a function from Int to Bool. 
+- In the above example, f is a function that takes a String and returns
+  a function from Int to Bool.
 
 - In order to make this more explicit, we could write:
 
@@ -21,15 +21,15 @@ f ::  String -> (Int -> Bool)
 
 - However, as the function arrow associates to the right, the parentheses
   can be (and usually are) omitted.
-  
+
 - The standard library defines a *higher order function* `curry`.
-  
-- This functions takes a single input argument: a function 
+
+- This functions takes a single input argument: a function
   that takes a pair (a, b) as input.
 
 - The output of this function is a *new function* that takes its inputs separately
   (a -> b -> c), rather than as a tuple/pair.
-  
+
 curry :: ((a, b) -> c) -> a -> b -> c
 
 - The inverse of `curry` is called `uncurry`.
@@ -41,8 +41,8 @@ uncurry :: (a -> b -> c) -> (a, b) -> c
 
 -}
 
--- The manhattan distance of two coordinate points is defined as 
--- the distance in x + the distance in y. 
+-- The manhattan distance of two coordinate points is defined as
+-- the distance in x + the distance in y.
 -- This function takes the xdistance and ydistance and calculates the manhattan distance:
 
 
@@ -59,7 +59,7 @@ manhattanDistance xdist ydist = abs xdist + abs ydist
 manhattanDistancePoint :: (Int, Int) -> Int
 manhattanDistancePoint = ???
 
--- This function takes a pair of booleans and returns a boolean 
+-- This function takes a pair of booleans and returns a boolean
 -- corresponding to their logical AND
 
 andPair :: (Bool, Bool) -> Bool

--- a/exercises/functions/Functions4.hs
+++ b/exercises/functions/Functions4.hs
@@ -41,7 +41,7 @@ multiplyBy6 = undefined
 -- TODO: Define your own operator, (%=%)!
 -- This should take two integers and produce another integer.
 -- It should multiply the inputs together, subtract the second from the first,
--- and then add the result. 
+-- and then add the result.
 -- 5 %=% 6 = 29
 
 -- Testing Code

--- a/exercises/lists/Lists3.hs
+++ b/exercises/lists/Lists3.hs
@@ -10,7 +10,7 @@ import Test.Tasty.HUnit
   has up to 3 components:
 
 1. The data source
-2. An optional filter 
+2. An optional filter
 3. The resulting data
 
 - Here's one example, which uppercases all the words which are

--- a/exercises/monads/Functors.hs
+++ b/exercises/monads/Functors.hs
@@ -75,7 +75,7 @@ data Metrics m = Metrics
 doubleMetrics :: Metrics Double -> Metrics Double
 doubleMetrics = undefined
 
--- 
+--
 
 m1 :: Metrics Double
 m1 = Metrics [3.0, 6.0] 4.5 6.0 3.0 Nothing

--- a/exercises/recursion/Recursion1.hs
+++ b/exercises/recursion/Recursion1.hs
@@ -19,7 +19,7 @@ import Test.Tasty.HUnit
   When the dividend (first input) is smaller than the divisor (second),
   the answer is 0. This is our *base case*.
 
-quotient :: Word -> Word -> Word 
+quotient :: Word -> Word -> Word
 quotient dividend divisor = if dividend < divisor
   then 0   -- < BASE CASE
   else ...

--- a/exercises/syntax/Syntax2.hs
+++ b/exercises/syntax/Syntax2.hs
@@ -31,7 +31,7 @@ example list1
 - Observe that the "equals" sign goes on each individual line, NOT after the
   initial function name and arguments!
 
-- Note: The cases are evaluated in the order they are listed. 
+- Note: The cases are evaluated in the order they are listed.
 -}
 
 -- TODO:

--- a/exercises/typeclasses/Typeclasses2.hs
+++ b/exercises/typeclasses/Typeclasses2.hs
@@ -5,7 +5,7 @@ import Test.Tasty.HUnit
 
 {-
 
-- Many times, we don't want to (or can't) use the default instances we get 
+- Many times, we don't want to (or can't) use the default instances we get
   from using 'deriving'. In these cases we'll have to define our own instances.
   In this case we use the 'instance' keyword like so:
 

--- a/exercises/typeclasses/Typeclasses4.hs
+++ b/exercises/typeclasses/Typeclasses4.hs
@@ -16,7 +16,7 @@ class Mathable a where
 - Then you simply list the function names and type signatures for the
   different functions you want in that class! These will almost always
   contain the variable type:
-  
+
 -}
 
 class Mathable a where


### PR DESCRIPTION
Remove:
  - trailing whitespaces at EOL in exercices/*

Fixes #66 